### PR TITLE
csys for pipe system not the same as notebook

### DIFF
--- a/BNS_JT/gen_bnb.py
+++ b/BNS_JT/gen_bnb.py
@@ -232,12 +232,12 @@ def core(brs, rules, rules_st, cst, stop_br):
 
     """
     brs_new = []
-
+    #print(f'brs entering core: {brs}')
     for i, br in enumerate(brs):
 
         up = {x: y for x, y in zip(br.names, br.up)}
         idx, _ = get_compat_rules(up, rules, rules_st)
-
+        #print(f'up, idx: {up}, {idx}')
         if br.up_state == 'unk' and len(idx) == 0:
             cst = br.up # perform analysis on this state
             stop_br = True
@@ -246,6 +246,7 @@ def core(brs, rules, rules_st, cst, stop_br):
         down = {x: y for x, y in zip(br.names, br.down)}
         idx, _ = get_compat_rules(down, rules, rules_st)
 
+        #print(f'down, idx: {down}, {idx}')
         if br.down_state == 'unk' and len(idx) == 0:
             cst = br.down # perform analysis on this state
             stop_br = True
@@ -279,11 +280,9 @@ def core(brs, rules, rules_st, cst, stop_br):
 
                 else:
                     b.down_state = cst_down
-
+                    brs_new.append(b)
                     if cst_down == cst_up:
                         b.is_complete = True
-
-                    brs_new.append(b)
 
             if stop_br == True:
                 break
@@ -299,12 +298,10 @@ def core(brs, rules, rules_st, cst, stop_br):
             if cst_down == cst_up:
                 b.is_complete = True
 
-        if stop_br == False:
-            brs = copy.deepcopy(brs_new)
-        else:
-            break
+    if stop_br == False:
+        brs = copy.deepcopy(brs_new)
 
-    return brs_new, cst, stop_br
+    return brs, cst, stop_br
 
 
 def init_brs(varis, rules, rules_st):
@@ -320,7 +317,7 @@ def init_brs(varis, rules, rules_st):
     return brs
 
 
-def do_gen_bnb(sys_fun, varis, max_br, output_path=Path(sys.argv[0]).parent, key=None, flag=True):
+def do_gen_bnb(sys_fun, varis, max_br, output_path=Path(sys.argv[0]).parent, key=None, flag=False):
     ### MAIN FUNCTION ####
     """
     Input:
@@ -354,6 +351,7 @@ def do_gen_bnb(sys_fun, varis, max_br, output_path=Path(sys.argv[0]).parent, key
 
         ## Start from the total event ##
         brs = init_brs(varis, rules, rules_st)
+        #print(f'brat at {no_iter}: {brs}')
         stop_br = False
 
         while ok:
@@ -367,7 +365,10 @@ def do_gen_bnb(sys_fun, varis, max_br, output_path=Path(sys.argv[0]).parent, key
 
         # update rules, rules_st
         sys_res_, rules, rules_st = get_sys_rules(cst, sys_fun, rules, rules_st, varis)
-        #print(f'go next iteration: {sys_res_["sys_val"].values[0]}')
+        #print(f'sys_res_: {sys_res_.values[0]}')
+        #print(f'rules: {rules}')
+        #print(f'rules_st: {rules_st}')
+        #print(f'brs: {brs}')
         sys_res = pd.concat([sys_res, sys_res_], ignore_index=True)
 
     ###############

--- a/BNS_JT/tests/test_gen_bnb.py
+++ b/BNS_JT/tests/test_gen_bnb.py
@@ -130,7 +130,7 @@ def setup_brs(main_sys):
     # Branch and bound
     output_path = Path(__file__).parent
     no_sf, rules, rules_st, brs, sys_res = gen_bnb.do_gen_bnb(sys_fun, varis, max_br=1000,
-                                                              output_path=output_path, key='bridge')
+                                                              output_path=output_path, key='bridge', flag=True)
 
     return no_sf, rules, rules_st, brs, sys_res
 
@@ -274,7 +274,9 @@ def test_core1(main_sys):
 
     brs, cst, stop_br = gen_bnb.core(brs, rules, rules_st, cst, stop_br)
 
-    assert brs == []
+    assert len(brs) == 1
+    assert brs[0].up == [2] * 6
+    assert brs[0].down == [0] * 6
     assert cst == [2, 2, 2, 2, 2, 2]
     assert stop_br == True
 
@@ -291,7 +293,9 @@ def test_core2(main_sys):
 
     #pdb.set_trace()
     brs, cst, stop_br = gen_bnb.core(brs, rules, rules_st, cst, stop_br)
-    assert brs == []
+    assert len(brs) == 1
+    assert brs[0].up == [2] * 6
+    assert brs[0].down == [0] * 6
     assert cst == [0, 0, 0, 0, 0, 0]
     assert stop_br == True
 
@@ -308,7 +312,9 @@ def test_core3(main_sys):
 
     #pdb.set_trace()
     brs, cst, stop_br = gen_bnb.core(brs, rules, rules_st, cst, stop_br)
-    assert brs == []
+    assert len(brs) == 1
+    assert brs[0].up == [2] * 6
+    assert brs[0].down == [0] * 6
     assert cst == [2, 2, 2, 2, 1, 2]
     assert stop_br == True
 
@@ -325,7 +331,9 @@ def test_core4(main_sys):
 
     #pdb.set_trace()
     brs, cst, stop_br = gen_bnb.core(brs, rules, rules_st, cst, stop_br)
-    assert brs == []
+    assert len(brs) == 1
+    assert brs[0].up == [2] * 6
+    assert brs[0].down == [0] * 6
     assert cst == [2, 1, 2, 2, 2, 2]
     assert stop_br == True
 
@@ -836,7 +844,13 @@ def test_get_csys_from_brs(main_sys):
     sys_fun = trans.sys_fun_wrap(od_pair, arcs, varis, thres * d_time_itc)
 
     # # Branch and bound
-    _, _, _, brs, _ = gen_bnb.do_gen_bnb(sys_fun, varis, max_br=1000)
+    file_brs = Path(__file__).parent.joinpath('brs_bridge.pk')
+    if file_brs.exists():
+        with open(file_brs, 'rb') as fi:
+            brs = pickle.load(fi)
+            print(f'{file_brs} loaded')
+    else:
+        _, _, _, brs, _ = request.getfixturevalue('setup_brs')
 
     st_br_to_cs = {'fail': 0, 'surv': 1, 'unk': 2}
 


### PR DESCRIPTION
still different result by test_get_csys_from_brs_pipe from the notebook (gen_bnb_to_rel_deter_ind_pipe.ipynb)
Brs from the gen_bnb seem right though.
I guess Brs are the same between pipe_system_v2.ipynb and gen_bnb_to_rel_deter_ind_pipe.ipynb?
Any thoughts?